### PR TITLE
Refactor component name

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image';
 
-import { ContentDetails, Button } from '@/components';
+import { Button, ContentLabels } from '@/components';
 
 interface Props {
   title: string;
   image: string;
-  items: ContentDetailsProps[];
+  items: ContentLabelsProps[];
 }
 
 function Card({ title, image, items }: Props) {
@@ -23,7 +23,7 @@ function Card({ title, image, items }: Props) {
         <header className="w-full">
           <h2 className="text-start font-grotesque text-2xl font-medium text-title-light md:text-3xl lg:text-4xl">{title}</h2>
         </header>
-        <ContentDetails items={items} />
+        <ContentLabels items={items} />
 
         {/**
          * @todo

--- a/components/ContentLabels.tsx
+++ b/components/ContentLabels.tsx
@@ -1,10 +1,10 @@
 import { Icon } from '@/components';
 
 interface Props {
-  items: ContentDetailsProps[];
+  items: ContentLabelsProps[];
 }
 
-function ContentDetails({ items }: Props) {
+function ContentLabels({ items }: Props) {
   return (
     <div className="border-border-light flex w-full flex-wrap gap-x-7 gap-y-2 border px-6 py-2 md:w-fit lg:py-6">
       {items.map(item => (
@@ -24,4 +24,4 @@ function ContentDetails({ items }: Props) {
   );
 }
 
-export default ContentDetails;
+export default ContentLabels;

--- a/components/index.ts
+++ b/components/index.ts
@@ -2,4 +2,4 @@ export { default as Brand } from './Brand';
 export { default as Button } from './Button';
 export { default as Icon } from './Icon';
 export { default as Card } from './Card';
-export { default as ContentDetails } from './ContentDetails';
+export { default as ContentLabels } from './ContentLabels';

--- a/modules/Home/mockData.ts
+++ b/modules/Home/mockData.ts
@@ -2,7 +2,7 @@ interface MockDataProps {
   id: number;
   title: string;
   image: string;
-  items: ContentDetailsProps[];
+  items: ContentLabelsProps[];
   slug: string;
 }
 

--- a/types/ContentLabelsProps.ts
+++ b/types/ContentLabelsProps.ts
@@ -1,4 +1,4 @@
-interface ContentDetailsProps {
+interface ContentLabelsProps {
   icon: IconLabelProps;
   label: string;
 }


### PR DESCRIPTION
Update component name to `ContentLabels` to prevent confusion between component and content details page.