### PR TITLE
Slider src fix

### DIFF
--- a/modules/Home/Slider/Slider.tsx
+++ b/modules/Home/Slider/Slider.tsx
@@ -11,7 +11,7 @@ interface Props {
   images: SliderImageProps[];
 }
 
-function Carousel({ images }: Props) {
+function Slider({ images }: Props) {
   const [emblaRef] = useEmblaCarousel(OPTIONS, [
     Autoplay({
       delay: 300,
@@ -43,8 +43,8 @@ function Carousel({ images }: Props) {
                 key={item.fields.title}
               >
                 <Image
-                  src={`https://${item.fields.file.url}`}
-                  alt="Your alt text"
+                  src={`https:${item.fields.file.url}`}
+                  alt={item.fields.title}
                   fill
                   className="absolute left-0 top-0 block h-full w-full object-cover"
                 />
@@ -57,4 +57,4 @@ function Carousel({ images }: Props) {
   );
 }
 
-export default Carousel;
+export default Slider;


### PR DESCRIPTION
Update `src prop` and remove redundant `//` characters to fix blank images bug on `Vercel` deployment.
Update component name.