### PR TITLE
Rich text renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "updatePackageVersions": "npx npm-check-updates -u && yarn install"
   },
   "dependencies": {
+    "@contentful/rich-text-react-renderer": "^15.19.6",
     "class-variance-authority": "^0.7.0",
     "contentful": "^10.8.6",
     "embla-carousel-autoplay": "7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@contentful/rich-text-react-renderer':
+    specifier: ^15.19.6
+    version: 15.19.6(react-dom@18.2.0)(react@18.2.0)
   class-variance-authority:
     specifier: ^0.7.0
     version: 0.7.0
@@ -112,6 +115,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+
+  /@contentful/rich-text-react-renderer@15.19.6(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-SPpkr2uSyirsN/uUaek8djqLMGP8nPqSqxoQ8M0VJcfD9+INKK56vjmteNr5dBbqAZO/PJMxT1S8to9BndpinQ==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@contentful/rich-text-types': 16.3.5
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /@contentful/rich-text-types@16.3.5:
     resolution: {integrity: sha512-ZLq6p5uyQXg+i1XGDFu4tAc2VYS12S1KA/jIOyyZjNgC1DvDajsi1JzuiBuOuMEhi1sKEUy6Ry3Yr9jsQtOKuQ==}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,4 +38,5 @@ const config: Config = {
     },
   },
 };
+
 export default config;

--- a/theme/globals.css
+++ b/theme/globals.css
@@ -5,10 +5,10 @@
 :root {
   --color-background: #161617;
   --color-background-light: #373737;
-  --color-text-light: #E1E1E1;
+  --color-text-light: #e1e1e1;
   --color-text-dark: #858585;
   --color-text-darker: #252525;
-  --color-button-background: #EDEDED;
+  --color-button-background: #ededed;
   --color-border-dark: #565656;
 }
 
@@ -17,13 +17,11 @@ body {
   --sb-thumb-color: var(--color-background);
   --sb-size: 12px;
 
-  scrollbar-color: 
-    var(--sb-thumb-color) 
-    var(--sb-track-color);
+  scrollbar-color: var(--sb-thumb-color) var(--sb-track-color);
 }
 
 body::-webkit-scrollbar {
-  width: var(--sb-size) 
+  width: var(--sb-size);
 }
 
 body::-webkit-scrollbar-track {
@@ -35,4 +33,29 @@ body::-webkit-scrollbar-thumb {
   background: var(--sb-thumb-color);
   border-radius: 1px;
   border: 3px solid var(--color-background-light);
+}
+
+/* Defines spacing values for this elements because tailwindcss normalizer removes default margins for typography elements. */
+.rich-text-renderer > h1,
+h2,
+h3,
+h4,
+h5 {
+  @apply mb-5 mt-7;
+}
+
+.rich-text-renderer h6 {
+  @apply my-3;
+}
+
+.rich-text-renderer p {
+  @apply mb-4;
+}
+
+.rich-text-renderer ul li p {
+  @apply mb-4;
+}
+
+.rich-text-renderer ul li h6 {
+  @apply my-3;
 }


### PR DESCRIPTION
Add `"@contentful/rich-text-react-renderer` dependency.
Add custom styles for rich text content because `tailwindcss` normalizers all typography rules.